### PR TITLE
runnable with different working dir

### DIFF
--- a/erajs/engine.py
+++ b/erajs/engine.py
@@ -122,11 +122,14 @@ class DataEngine(EventEngine):
             # frozen
             d = os.path.dirname(sys.executable)
             gamepath = os.path.dirname(d)
+            workingpath = d
         else:
             # unfrozen
             d = os.path.dirname(os.path.realpath(__file__))
             gamepath = os.path.dirname(os.path.dirname(d))
+            workingpath = os.path.dirname(d)
         sys.path.append(gamepath)
+        os.chdir(workingpath)
 
     def self_check(self):
         self.data = {


### PR DESCRIPTION
用os.chdir指定了工作目录，防止从其他目录启动时找不到文件